### PR TITLE
Terminal start/stop & import private repos

### DIFF
--- a/client/src/components/ImportModal.tsx
+++ b/client/src/components/ImportModal.tsx
@@ -75,7 +75,7 @@ export default function ImportModal({ isOpen, onClose, onSuccess }: ImportModalP
 
 						<div className="p-6">
 							<p className="text-sm text-gray-400 mb-4">
-								Enter a public GitHub repository URL to securely clone into your isolated workspace.
+								Enter a GitHub repository URL to clone into your isolated workspace. Private repos require a GitHub token set in your profile.
 							</p>
 
 							<div className="flex flex-col gap-2 mb-6">

--- a/client/src/components/TerminalArea.tsx
+++ b/client/src/components/TerminalArea.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Terminal } from "xterm";
 import { FitAddon } from "xterm-addon-fit";
 import "xterm/css/xterm.css";
-import { Terminal as TerminalIcon, StopCircle, X, Globe, Lock, RefreshCw } from "lucide-react";
+import { Terminal as TerminalIcon, StopCircle, Play, X, Globe, Lock, RefreshCw } from "lucide-react";
 import { WS_BASE, API_BASE } from "@/lib/config";
 
 interface TerminalTab {
@@ -17,6 +17,7 @@ export default function TerminalArea({ projectId }: { projectId: string | null }
     ]);
     const [activeTabId, setActiveTabId] = useState("term-1");
     const [isConnected, setIsConnected] = useState(false);
+    const [isStopped, setIsStopped] = useState(false);
     const [previewUrl, setPreviewUrl] = useState(() => API_BASE.replace(/^https?:\/\//, ""));
 
     const termInstances = useRef<Record<string, Terminal>>({});
@@ -30,6 +31,7 @@ export default function TerminalArea({ projectId }: { projectId: string | null }
 
             ws.onopen = () => {
                 setIsConnected(true);
+                setIsStopped(false);
                 const activeTab = tabs.find(t => t.id === activeTabId);
                 if (activeTab?.type === "terminal") {
                     const term = termInstances.current[activeTabId];
@@ -39,6 +41,19 @@ export default function TerminalArea({ projectId }: { projectId: string | null }
 
             ws.onmessage = (event) => {
                 const data = event.data;
+                // Check for JSON control messages from the server
+                if (typeof data === "string" && data.startsWith('{"type":')) {
+                    try {
+                        const msg = JSON.parse(data);
+                        if (msg.type === "container_stopped") {
+                            setIsStopped(true);
+                            Object.values(termInstances.current).forEach(term =>
+                                term.writeln("\r\n\x1b[33m[Container stopped — click Start to resume]\x1b[0m")
+                            );
+                            return;
+                        }
+                    } catch (_) {}
+                }
                 Object.values(termInstances.current).forEach(term => {
                     if (typeof data === "string") {
                         term.write(data);
@@ -162,6 +177,13 @@ useEffect(() => {
         }
     };
 
+    const handleStart = () => {
+        setIsStopped(false);
+        if (wsInstance.current?.readyState === WebSocket.OPEN) {
+            wsInstance.current.send(JSON.stringify({ type: "start" }));
+        }
+    };
+
 	return (
 		<div className="flex flex-col h-full bg-[#09090b] text-white">
 			<div className="flex items-center justify-between px-2 bg-[#18181b] border-b border-[#27272a] shrink-0">
@@ -202,15 +224,22 @@ useEffect(() => {
 				</div>
 
                 <div className="flex items-center gap-2 pr-2 shrink-0">
-                    <span className={`w-1.5 h-1.5 rounded-full ${isConnected ? "bg-green-400 shadow-[0_0_6px_rgba(74,222,128,0.6)]" : "bg-gray-600"}`} />
-                    {isConnected && (
+                    <span className={`w-1.5 h-1.5 rounded-full ${isConnected && !isStopped ? "bg-green-400 shadow-[0_0_6px_rgba(74,222,128,0.6)]" : isStopped ? "bg-yellow-500" : "bg-gray-600"}`} />
+                    {isStopped ? (
+                        <button
+                            onClick={handleStart}
+                            className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-green-400 hover:text-green-300 hover:bg-green-500/10 rounded transition-colors border border-transparent hover:border-green-500/20"
+                        >
+                            <Play size={11} /> Start
+                        </button>
+                    ) : isConnected ? (
                         <button
                             onClick={handleStop}
                             className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-red-400 hover:text-red-300 hover:bg-red-500/10 rounded transition-colors border border-transparent hover:border-red-500/20"
                         >
                             <StopCircle size={11} /> Stop
                         </button>
-                    )}
+                    ) : null}
                 </div>
 			</div>
 

--- a/client/src/routes/dashboard.tsx
+++ b/client/src/routes/dashboard.tsx
@@ -4,6 +4,7 @@ import { Loader2, X, ExternalLink } from "lucide-react";
 import { useState, useEffect, useRef } from "react";
 import CoderMatchModal from "../components/CoderMatchModal";
 import GamePIP from "../components/GamePIP";
+import ImportModal from "../components/ImportModal";
 import { API_BASE } from "@/lib/config";
 
 export const Route = createFileRoute("/dashboard")({
@@ -56,6 +57,7 @@ function DashboardPage() {
   const [activeFilter, setActiveFilter] = useState<'all' | 'recent'>('all');
   const [deployedApps, setDeployedApps] = useState<DeployedApp[]>([]);
   const [isLoadingApps, setIsLoadingApps] = useState(false);
+  const [showImportModal, setShowImportModal] = useState(false);
 
   const reposRef = useRef<HTMLDivElement>(null);
   const recentRef = useRef<HTMLDivElement>(null);
@@ -134,6 +136,10 @@ function DashboardPage() {
       setError(err.message);
       setImportingRepoId(null);
     }
+  };
+
+  const handleImportSuccess = (projectId: string) => {
+    navigate({ to: "/", search: { w: projectId } });
   };
 
   const handleCreateRepo = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -330,7 +336,7 @@ function DashboardPage() {
             <span className="font-['Space_Grotesk'] text-[10px] uppercase tracking-[0.2em] font-bold">Recent</span>
           </div>
           <div
-            onClick={() => scrollToSection(reposRef)}
+            onClick={() => setShowImportModal(true)}
             className="flex items-center gap-5 px-6 py-3.5 rounded text-slate-500 hover:bg-white/5 hover:text-[#f8fafc] transition-all cursor-pointer"
           >
             <span className="material-symbols-outlined text-xl">upload_file</span>
@@ -457,7 +463,7 @@ function DashboardPage() {
                 })}
                 {/* Import Card */}
                 <div
-                  onClick={() => scrollToSection(reposRef)}
+                  onClick={() => setShowImportModal(true)}
                   className="bg-transparent border-2 border-dashed border-[rgba(168,85,247,0.2)] group p-10 rounded-xl flex flex-col items-center justify-center text-center hover:bg-white/5 transition-all relative overflow-hidden cursor-pointer"
                 >
                   <div className="w-16 h-16 rounded-xl bg-[rgba(10,12,20,0.4)] flex items-center justify-center mb-8 text-slate-600 group-hover:text-[#A855F7] transition-colors border border-[rgba(168,85,247,0.1)]">
@@ -631,6 +637,13 @@ function DashboardPage() {
       {showCoderMatch && (
         <CoderMatchModal onClose={() => setShowCoderMatch(false)} />
       )}
+
+      {/* Import Repository Modal */}
+      <ImportModal
+        isOpen={showImportModal}
+        onClose={() => setShowImportModal(false)}
+        onSuccess={handleImportSuccess}
+      />
 
       {/* Game PIP */}
       {showGame && (

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -290,9 +290,12 @@ interface TerminalRoom {
     sink: import("bun").FileSink; // typed stdin pipe
 }
 
-const termClients     = new Map<string, Set<import("bun").ServerWebSocket<WSData>>>();
-const termRooms       = new Map<string, TerminalRoom>();
-const termLineBuffers = new Map<string, string>(); // per-room line edit buffer
+const termClients       = new Map<string, Set<import("bun").ServerWebSocket<WSData>>>();
+const termRooms         = new Map<string, TerminalRoom>();
+const termLineBuffers   = new Map<string, string>(); // per-room line edit buffer
+const termCleanupTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const termBootstrapping = new Set<string>(); // rooms whose container is being created (race-condition lock)
+const termStopped       = new Set<string>(); // rooms manually stopped by the user
 
 // Per project+file event counter for checkpoint marking.
 // NOTE: resets on server restart — checkpoints are cosmetic anchors, not exact.
@@ -304,6 +307,8 @@ async function stopTerminal(roomId: string): Promise<void> {
     termRooms.delete(roomId);
     termClients.delete(roomId);
     termLineBuffers.delete(roomId);
+    const pending = termCleanupTimers.get(roomId);
+    if (pending) { clearTimeout(pending); termCleanupTimers.delete(roomId); }
 
     clients?.forEach(c => {
         try { c.send("\r\n\x1b[33m[Container stopped]\x1b[0m\r\n"); } catch (_) {}
@@ -314,6 +319,124 @@ async function stopTerminal(roomId: string): Promise<void> {
         try { await room.container.stop({ t: 5 }); } catch (_) {}
         try { await room.container.remove(); } catch (_) {}
         console.log(`[Terminal] Cleaned up container for room ${roomId}`);
+    }
+}
+
+async function bootstrapRoom(roomId: string): Promise<void> {
+    if (termBootstrapping.has(roomId)) return; // lock — prevent concurrent bootstraps for the same room
+    termBootstrapping.add(roomId);
+
+    const broadcastToRoom = (msg: string) =>
+        termClients.get(roomId)?.forEach(c => { try { c.send(msg); } catch (_) {} });
+
+    let container: Docker.Container | null = null;
+    try {
+        broadcastToRoom("\x1b[1;36m[VibeCodium]\x1b[0m Syncing project files...\r\n");
+        const hostDir = await syncProjectFilesToDisk(roomId);
+
+        const { data: projectFiles } = await supabase
+            .from("files")
+            .select("path, content")
+            .eq("project_id", roomId);
+
+        const scanResult = await scanCode(
+            (projectFiles ?? [])
+                .filter((f) => f.content)
+                .map((f) => ({ path: f.path, content: f.content! }))
+        );
+
+        if (!scanResult.safe) {
+            broadcastToRoom("\x1b[1;31m[🛡️ SECURITY BLOCK]\x1b[0m Critical vulnerabilities detected:\r\n\r\n");
+            scanResult.vulnerabilities
+                .filter((v) => v.severity === "critical" || v.severity === "high")
+                .forEach((v) => {
+                    broadcastToRoom(`  \x1b[31m● ${v.severity.toUpperCase()}\x1b[0m: ${v.description}\r\n`);
+                    broadcastToRoom(`    Code: ${v.code}\r\n`);
+                    broadcastToRoom(`    Fix: ${v.recommendation}\r\n\r\n`);
+                });
+            broadcastToRoom("\x1b[33mExecution refused for safety. Fix issues and try again.\x1b[0m\r\n");
+            termClients.get(roomId)?.forEach(c => c.close(1008, "Security policy violation"));
+            return;
+        }
+
+        broadcastToRoom(`\x1b[32m✓ Security scan passed\x1b[0m (${scanResult.scannedFiles} files, ${scanResult.scannedLines} lines, ${scanResult.scanDuration}ms)\r\n`);
+
+        const image = detectTerminalImage((projectFiles ?? []).map(f => f.path));
+        broadcastToRoom(`\x1b[90mImage: ${image}  |  ${hostDir} → /usr/src/app\x1b[0m\r\n`);
+
+        if (!image.startsWith("vibecodium-")) {
+            broadcastToRoom("\x1b[90mPulling image...\x1b[0m\r\n");
+            await new Promise<void>((res, rej) => {
+                docker.pull(image, (err: Error | null, pullStream: any) => {
+                    if (err) return rej(err);
+                    pullStream.on("data", () => {});
+                    pullStream.on("end", res);
+                    pullStream.on("error", rej);
+                });
+            });
+        }
+
+        container = await docker.createContainer({
+            Image: image,
+            Cmd: ["sleep", "infinity"],
+            Tty: false,
+            WorkingDir: "/usr/src/app",
+            HostConfig: {
+                Memory: 2048 * 1024 * 1024,
+                MemorySwap: 2048 * 1024 * 1024,
+                CpuQuota: 50000,
+                CpuPeriod: 100000,
+                PidsLimit: 50,
+                Binds: [`${hostDir}:/usr/src/app`],
+                AutoRemove: false,
+            },
+        });
+        await container.start();
+
+        const proc = Bun.spawn(
+            ["docker", "exec", "-i", container.id, "/bin/sh", "-i"],
+            { stdin: "pipe", stdout: "pipe", stderr: "pipe" }
+        );
+
+        const sink = proc.stdin as import("bun").FileSink;
+        termRooms.set(roomId, { container, proc, sink });
+
+        (async () => {
+            const reader = proc.stdout.getReader();
+            const dec = new TextDecoder();
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                broadcastToRoom(dec.decode(value).replace(/\r?\n/g, "\r\n"));
+            }
+            broadcastToRoom("\r\n\x1b[33m[Shell exited]\x1b[0m\r\n");
+            stopTerminal(roomId);
+        })();
+
+        (async () => {
+            const reader = proc.stderr.getReader();
+            const dec = new TextDecoder();
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                broadcastToRoom(dec.decode(value).replace(/\r?\n/g, "\r\n"));
+            }
+        })();
+
+        broadcastToRoom("\x1b[1;32m[Ready]\x1b[0m Sandbox started. Working dir: \x1b[33m/usr/src/app\x1b[0m\r\n\r\n");
+
+    } catch (e: any) {
+        if (container) {
+            try { await container.stop({ t: 0 }); } catch (_) {}
+            try { await container.remove(); } catch (_) {}
+        }
+        termClients.get(roomId)?.forEach(c => {
+            try { c.send(`\x1b[1;31m[Error]\x1b[0m ${e.message}\r\n`); } catch (_) {}
+            c.close(1011, e.message);
+        });
+        console.error("[Terminal] Container start failed:", e.message);
+    } finally {
+        termBootstrapping.delete(roomId); // always release the lock
     }
 }
 
@@ -430,136 +553,23 @@ export default {
                 if (!termClients.has(roomId)) termClients.set(roomId, new Set());
                 termClients.get(roomId)!.add(ws);
 
-                // If room already running, just attach to the broadcast stream
-                if (termRooms.has(roomId)) {
+                // Attach to running room
+                if (termRooms.has(roomId) || termBootstrapping.has(roomId)) {
+                    // Cancel any pending cleanup — client reconnected in time (e.g. page refresh)
+                    const pending = termCleanupTimers.get(roomId);
+                    if (pending) { clearTimeout(pending); termCleanupTimers.delete(roomId); }
                     ws.send("\x1b[90m[Joined existing terminal session]\x1b[0m\r\n");
                     return;
                 }
 
-                // ── First client: bootstrap Docker container ──
-                (async () => {
-                    const broadcastToRoom = (msg: string) =>
-                        termClients.get(roomId)?.forEach(c => { try { c.send(msg); } catch (_) {} });
+                // User previously stopped this container — notify and wait for explicit start
+                if (termStopped.has(roomId)) {
+                    ws.send(JSON.stringify({ type: "container_stopped" }));
+                    return;
+                }
 
-                    let container: Docker.Container | null = null;
-                    try {
-                        broadcastToRoom("\x1b[1;36m[VibeCodium]\x1b[0m Syncing project files...\r\n");
-                        const hostDir = await syncProjectFilesToDisk(roomId);
-
-                        // Load file list for language detection + security scan
-                        const { data: projectFiles } = await supabase
-                            .from("files")
-                            .select("path, content")
-                            .eq("project_id", roomId);
-
-                        // Security scan — block before any container starts
-						const scanResult = await scanCode(
-							(projectFiles ?? [])
-								.filter((f) => f.content)
-								.map((f) => ({ path: f.path, content: f.content! }))
-						);
-
-						if (!scanResult.safe) {
-							broadcastToRoom("\x1b[1;31m[🛡️ SECURITY BLOCK]\x1b[0m Critical vulnerabilities detected:\r\n\r\n");
-							scanResult.vulnerabilities
-								.filter((v) => v.severity === "critical" || v.severity === "high")
-								.forEach((v) => {
-									broadcastToRoom(`  \x1b[31m● ${v.severity.toUpperCase()}\x1b[0m: ${v.description}\r\n`);
-									broadcastToRoom(`    Code: ${v.code}\r\n`);
-									broadcastToRoom(`    Fix: ${v.recommendation}\r\n\r\n`);
-								});
-							broadcastToRoom("\x1b[33mExecution refused for safety. Fix issues and try again.\x1b[0m\r\n");
-							termClients.get(roomId)?.forEach(c => c.close(1008, "Security policy violation"));
-							return;
-						}
-
-						broadcastToRoom(`\x1b[32m✓ Security scan passed\x1b[0m (${scanResult.scannedFiles} files, ${scanResult.scannedLines} lines, ${scanResult.scanDuration}ms)\r\n`);
-
-                        // Pick image from file extensions
-                        const image = detectTerminalImage((projectFiles ?? []).map(f => f.path));
-                        broadcastToRoom(`\x1b[90mImage: ${image}  |  ${hostDir} → /usr/src/app\x1b[0m\r\n`);
-
-                        // Pull image (instant if already cached)
-                        // NOTE: docker.modem.followProgress hangs in Bun — drain raw stream events instead
-                        if (!image.startsWith("vibecodium-")) {
-                            broadcastToRoom("\x1b[90mPulling image...\x1b[0m\r\n");
-                            await new Promise<void>((res, rej) => {
-                                docker.pull(image, (err: Error | null, pullStream: any) => {
-                                    if (err) return rej(err);
-                                    pullStream.on("data", () => {}); // drain
-                                    pullStream.on("end", res);
-                                    pullStream.on("error", rej);
-                                });
-                            });
-                        }
-
-                        // Create container — sleep infinity as PID 1 (keeps it alive for docker exec)
-                        // NOTE: container.attach({hijack:true}) hangs in Bun — use Bun.spawn docker exec instead
-                        container = await docker.createContainer({
-                            Image: image,
-                            Cmd: ["sleep", "infinity"],
-                            Tty: false,
-                            WorkingDir: "/usr/src/app",
-                            HostConfig: {
-                                Memory: 2048 * 1024 * 1024,
-                                MemorySwap: 2048 * 1024 * 1024,
-                                CpuQuota: 50000,
-                                CpuPeriod: 100000,
-                                PidsLimit: 50,
-                                Binds: [`${hostDir}:/usr/src/app`],
-                                AutoRemove: false,
-                            },
-                        });
-                        await container.start();
-
-                        // Spawn interactive shell via docker exec (Bun-compatible approach)
-                        const proc = Bun.spawn(
-                            ["docker", "exec", "-i", container.id, "/bin/sh", "-i"],
-                            { stdin: "pipe", stdout: "pipe", stderr: "pipe" }
-                        );
-
-                        const sink = proc.stdin as import("bun").FileSink;
-                        termRooms.set(roomId, { container, proc, sink });
-
-                        // Pipe stdout → clients (normalize bare LF → CRLF for xterm)
-                        (async () => {
-                            const reader = proc.stdout.getReader();
-                            const dec = new TextDecoder();
-                            while (true) {
-                                const { done, value } = await reader.read();
-                                if (done) break;
-                                broadcastToRoom(dec.decode(value).replace(/\r?\n/g, "\r\n"));
-                            }
-                            broadcastToRoom("\r\n\x1b[33m[Shell exited]\x1b[0m\r\n");
-                            stopTerminal(roomId);
-                        })();
-
-                        // Pipe stderr → clients
-                        (async () => {
-                            const reader = proc.stderr.getReader();
-                            const dec = new TextDecoder();
-                            while (true) {
-                                const { done, value } = await reader.read();
-                                if (done) break;
-                                broadcastToRoom(dec.decode(value).replace(/\r?\n/g, "\r\n"));
-                            }
-                        })();
-
-                        broadcastToRoom("\x1b[1;32m[Ready]\x1b[0m Sandbox started. Working dir: \x1b[33m/usr/src/app\x1b[0m\r\n\r\n");
-
-                    } catch (e: any) {
-                        // Cleanup partially-created container on error
-                        if (container) {
-                            try { await container.stop({ t: 0 }); } catch (_) {}
-                            try { await container.remove(); } catch (_) {}
-                        }
-                        termClients.get(roomId)?.forEach(c => {
-                            try { c.send(`\x1b[1;31m[Error]\x1b[0m ${e.message}\r\n`); } catch (_) {}
-                            c.close(1011, e.message);
-                        });
-                        console.error("[Terminal] Container start failed:", e.message);
-                    }
-                })();
+                // First client for this room — bootstrap container
+                bootstrapRoom(roomId);
                 return;
             }
 
@@ -599,27 +609,35 @@ export default {
 
         message(ws: import("bun").ServerWebSocket<WSData>, message: string) {
             if (ws.data.type === "terminal") {
-                const room = termRooms.get(ws.data.projectId);
-                if (!room) return;
-                // JSON control messages
+                const roomId = ws.data.projectId;
+
+                // JSON control messages — handled before the room guard so stop/start work in any state
                 try {
                     const msg = JSON.parse(message);
                     if (msg.type === "resize") {
-                        // No PTY — resize is a no-op; ignore silently
-                        return;
+                        return; // no PTY — no-op
                     }
                     if (msg.type === "stop") {
-                        stopTerminal(ws.data.projectId);
+                        termStopped.add(roomId); // persist stopped intent across reconnects
+                        stopTerminal(roomId);
+                        return;
+                    }
+                    if (msg.type === "start") {
+                        termStopped.delete(roomId);
+                        if (!termRooms.has(roomId) && !termBootstrapping.has(roomId)) {
+                            bootstrapRoom(roomId);
+                        }
                         return;
                     }
                 } catch { /* not JSON — treat as raw stdin */ }
 
+                const room = termRooms.get(ws.data.projectId);
+                if (!room) return;
+
                 // Server-side line buffering (no PTY = no kernel line discipline)
                 // We echo characters locally and only flush the line to the shell on Enter.
                 const broadcastAll = (msg: string) =>
-                    termClients.get(ws.data.projectId)?.forEach(c => { try { c.send(msg); } catch (_) {} });
-
-                const roomId = ws.data.projectId;
+                    termClients.get(roomId)?.forEach(c => { try { c.send(msg); } catch (_) {} });
 
                 if (message === "\r" || message === "\n") {
                     // Enter — flush buffered line to shell
@@ -796,8 +814,15 @@ export default {
                 const clients = termClients.get(roomId);
                 if (clients) {
                     clients.delete(ws);
-                    // Stop container when the last client disconnects
-                    if (clients.size === 0) stopTerminal(roomId);
+                    // Defer cleanup — give the client 30s to reconnect (handles page refreshes)
+                    if (clients.size === 0 && !termCleanupTimers.has(roomId)) {
+                        const timer = setTimeout(() => {
+                            const current = termClients.get(roomId);
+                            if (!current || current.size === 0) stopTerminal(roomId);
+                            termCleanupTimers.delete(roomId);
+                        }, 30_000);
+                        termCleanupTimers.set(roomId, timer);
+                    }
                 }
                 return;
             }

--- a/server/src/routes/github.ts
+++ b/server/src/routes/github.ts
@@ -15,9 +15,9 @@ async function ghHeaders(auth0Id?: string): Promise<Record<string, string>> {
         Accept: "application/vnd.github.v3+json",
         "User-Agent": "VibeCodium-App",
     };
-    
+
     let token = process.env.GITHUB_TOKEN;
-    
+
     if (auth0Id) {
         const userTokens = await getUserTokens(auth0Id);
         if (userTokens.githubToken) {

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -117,6 +117,13 @@ projectsRoutes.post("/import", async (c) => {
         const user = (c.get as any)("user");
         const userId = user?.sub ?? "anonymous";
 
+        // Build authenticated clone URL if user has a GitHub token (required for private repos)
+        const tokens = await getUserTokens(userId);
+        const githubToken = tokens.githubToken || process.env.GITHUB_TOKEN_REPO || process.env.GITHUB_TOKEN;
+        const cloneUrl = githubToken && githubToken !== "undefined" && repoUrl.startsWith("https://github.com/")
+            ? repoUrl.replace("https://github.com/", `https://${githubToken}@github.com/`)
+            : repoUrl;
+
         // Check if already imported
         const { data: existing } = await supabase
             .from("projects")
@@ -146,7 +153,7 @@ projectsRoutes.post("/import", async (c) => {
                     console.log(`Re-cloning project ${projectId}...`);
                     await supabase.from("projects").update({ status: "cloning" }).eq("id", projectId);
                     fs.mkdirSync("/tmp/vibecodium", { recursive: true });
-                    const cloneProc = Bun.spawn(["git", "clone", repoUrl, targetDir], { stdout: "pipe", stderr: "pipe" });
+                    const cloneProc = Bun.spawn(["git", "clone", cloneUrl, targetDir], { stdout: "pipe", stderr: "pipe" });
                     if (await cloneProc.exited !== 0) {
                         const errText = await new Response(cloneProc.stderr).text();
                         await supabase.from("projects").update({ status: "error" }).eq("id", projectId);
@@ -177,7 +184,7 @@ projectsRoutes.post("/import", async (c) => {
         if (insertErr) throw insertErr;
 
         fs.mkdirSync("/tmp/vibecodium", { recursive: true });
-        const proc = Bun.spawn(["git", "clone", repoUrl, targetDir], { stdout: "pipe", stderr: "pipe" });
+        const proc = Bun.spawn(["git", "clone", cloneUrl, targetDir], { stdout: "pipe", stderr: "pipe" });
         const exitCode = await proc.exited;
 
         if (exitCode !== 0) {


### PR DESCRIPTION
Server: add robust terminal lifecycle management and bootstrapping — introduce termBootstrapping, termStopped and termCleanupTimers to avoid race conditions, persist manual stop intent, and defer cleanup (30s) for reconnects. Extract container startup into bootstrapRoom which syncs files, runs a security scan (blocks on critical/high findings), detects/pulls images, creates Docker containers and spawns shells. Handle JSON control messages (start/stop/resize) over the terminal websocket and emit container_stopped to clients.

Client: TerminalArea now reacts to server container_stopped events, shows a yellow stopped indicator and a Start button (Play icon) to resume; added isStopped state and handleStart. ImportModal copy updated to mention GitHub token for private repos. Dashboard: add ImportModal integration and open it from import cards; navigate to workspace on import success.

Projects route: support cloning private repos by building an authenticated clone URL using the user's GitHub token (or env token) and use that URL for git clone. Minor whitespace cleanup in github route.