### PR TITLE
35 vibematch persistent matches in match messaging and developer discovery filters

### DIFF
--- a/client/src/components/CoderMatchModal.tsx
+++ b/client/src/components/CoderMatchModal.tsx
@@ -1,157 +1,663 @@
-import { Heart, X, Flame, MapPin, Code2, Loader2 } from "lucide-react";
-import { useState, useEffect } from "react";
+import {
+	Heart,
+	X,
+	Flame,
+	MapPin,
+	Code2,
+	Loader2,
+	RotateCcw,
+	MessageCircle,
+	ChevronLeft,
+	Send,
+	UserX,
+} from "lucide-react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useAuth } from "@/contexts/AuthProvider";
-import { API_BASE } from "@/lib/config";
+import { API_BASE, WS_BASE } from "@/lib/config";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
 
 interface MatchUser {
-    auth0Id: string;
-    name: string;
-    email: string;
-    picture: string;
-    bio: string;
-    language: string;
-    location: string;
+	id: string;
+	name: string;
+	email: string;
+	picture: string;
+	bio: string;
+	language: string;
+	location: string;
 }
 
+interface MatchEntry {
+	id: string;
+	partner: { id: string; name: string; picture: string } | null;
+	lastMessage: { body: string; sender_id: string; created_at: string } | null;
+	unreadCount: number;
+	createdAt: string;
+}
+
+interface Message {
+	id: string;
+	sender_id: string;
+	body: string;
+	created_at: string;
+}
+
+type OrderMode = "random" | "language" | "location" | "active" | "new";
+type Screen = "swipe" | "matches";
+
+const ORDER_LABELS: Record<OrderMode, string> = {
+	random: "Hot right now",
+	language: "Same stack",
+	location: "Nearby",
+	active: "Most active",
+	new: "Just joined",
+};
+
+const ICEBREAKERS = [
+	"Do you also push to main on Fridays or is that just me?",
+	"Tab or spaces? (This could make or break us.)",
+	"What's your longest-running TODO comment?",
+	"Have you ever shipped a bug on purpose and called it a 'feature'?",
+	"Coffee before or after you read the error logs?",
+];
+
+// ── Main component ────────────────────────────────────────────────────────────
+
 export default function CoderMatchModal({ onClose }: { onClose: () => void }) {
-    const [currentIndex, setCurrentIndex] = useState(0);
-    const [matchMode, setMatchMode] = useState(false);
-    const [users, setUsers] = useState<MatchUser[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
+	const { user, getAccessTokenSilently } = useAuth();
 
-    const { getAccessTokenSilently } = useAuth();
+	// Navigation
+	const [screen, setScreen] = useState<Screen>("swipe");
 
-    useEffect(() => {
-        let isMounted = true;
-        const fetchUsers = async () => {
-            try {
-                const token = await getAccessTokenSilently();
-                const res = await fetch(`${API_BASE}/api/users/match`, {
-                    headers: { Authorization: `Bearer ${token}` }
-                });
-                const data = await res.json();
-                if (data.success && isMounted) {
-                    setUsers(data.users || []);
-                }
-            } catch (err) {
-                console.error("Failed to fetch match users:", err);
-            } finally {
-                if (isMounted) setIsLoading(false);
-            }
-        };
-        fetchUsers();
-        return () => { isMounted = false; };
-    }, [getAccessTokenSilently]);
+	// Swipe screen state
+	const [order, setOrder] = useState<OrderMode>("random");
+	const [users, setUsers] = useState<MatchUser[]>([]);
+	const [currentIndex, setCurrentIndex] = useState(0);
+	const [isLoadingUsers, setIsLoadingUsers] = useState(true);
+	const [matchAnimation, setMatchAnimation] = useState<{ user: MatchUser; matchId: string } | null>(null);
+	const [rewound, setRewound] = useState(false);
+	const [lastSwipedUser, setLastSwipedUser] = useState<MatchUser | null>(null);
 
-    const handleSwipe = (direction: 'left' | 'right') => {
-        if (direction === 'right' && Math.random() > 0.5) {
-            setMatchMode(true);
-            setTimeout(() => {
-                setMatchMode(false);
-                setCurrentIndex(prev => prev + 1);
-            }, 2000);
-        } else {
-            setCurrentIndex(prev => prev + 1);
-        }
-    };
+	// Matches screen state
+	const [matches, setMatches] = useState<MatchEntry[]>([]);
+	const [isLoadingMatches, setIsLoadingMatches] = useState(false);
 
-    if (isLoading) {
-        return (
-            <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm">
-                <div className="bg-[#18181b] border border-[#27272a] rounded-2xl p-8 flex flex-col items-center">
-                    <Loader2 size={32} className="animate-spin text-pink-500 mb-4" />
-                    <p className="text-white font-medium">Finding hot coders in your area...</p>
-                </div>
-            </div>
-        );
-    }
+	// Chat state
+	const [activeMatchId, setActiveMatchId] = useState<string | null>(null);
+	const [messages, setMessages] = useState<Message[]>([]);
+	const [isLoadingMessages, setIsLoadingMessages] = useState(false);
+	const [messageInput, setMessageInput] = useState("");
+	const [isSending, setIsSending] = useState(false);
+	const wsRef = useRef<WebSocket | null>(null);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
 
-    if (currentIndex >= users.length) {
-        return (
-            <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm">
-                <div className="bg-[#18181b] border border-[#27272a] rounded-2xl p-8 max-w-sm w-full text-center relative shadow-2xl">
-                    <button onClick={onClose} className="absolute top-4 right-4 text-gray-500 hover:text-white transition-colors">
-                        <X size={20} />
-                    </button>
-                    <Flame className="w-16 h-16 text-pink-500 mx-auto mb-4" />
-                    <h2 className="text-2xl font-bold text-white mb-2">No more coders!</h2>
-                    <p className="text-gray-400 text-sm">You ran out of hot singles in your area. Go back to coding.</p>
-                </div>
-            </div>
-        );
-    }
+	// ── Fetch swipe candidates ─────────────────────────────────────────────────
 
-    const profile = users[currentIndex];
-    
-    // Generate a pseudo-random age based on ID length
-    const pseudoAge = 20 + (profile.auth0Id ? (profile.auth0Id.length % 15) : 4);
+	const fetchUsers = useCallback(async (orderMode: OrderMode) => {
+		setIsLoadingUsers(true);
+		setCurrentIndex(0);
+		try {
+			const token = await getAccessTokenSilently();
+			const res = await fetch(`${API_BASE}/api/users/match?order=${orderMode}`, {
+				headers: { Authorization: `Bearer ${token}` },
+			});
+			const data = await res.json();
+			if (data.success) setUsers(data.users ?? []);
+		} catch (err) {
+			console.error("Failed to fetch match users:", err);
+		} finally {
+			setIsLoadingUsers(false);
+		}
+	}, [getAccessTokenSilently]);
 
-    return (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-            <div className="bg-[#09090b] border border-[#27272a] rounded-3xl overflow-hidden max-w-sm w-full relative shadow-[0_0_50px_rgba(236,72,153,0.15)] flex flex-col h-[600px]">
-                {matchMode && (
-                    <div className="absolute inset-0 z-50 bg-black/90 flex flex-col items-center justify-center p-6 text-center animate-out fade-out duration-300">
-                        <h2 className="text-4xl font-black text-transparent bg-clip-text bg-gradient-to-r from-pink-500 to-rose-500 italic mb-4 -rotate-12">IT'S A MATCH!</h2>
-                        <p className="text-white mb-8 text-lg font-medium">You and {profile.name} both love avoiding documentation.</p>
-                        <div className="flex gap-4">
-                            <img src={profile.picture} alt={profile.name} className="w-24 h-24 rounded-full border-4 border-pink-500 bg-white" />
-                            <div className="w-24 h-24 rounded-full border-4 border-pink-500 flex items-center justify-center bg-gradient-to-br from-cyan-400 to-blue-600 font-bold text-2xl text-black">
-                                iT
-                            </div>
-                        </div>
-                    </div>
-                )}
+	useEffect(() => {
+		fetchUsers(order);
+	}, [order, fetchUsers]);
 
-                {/* Header */}
-                <div className="p-4 border-b border-[#27272a] flex justify-between items-center bg-[#18181b]">
-                    <div className="flex items-center gap-2 text-pink-500 font-bold text-xl tracking-tight">
-                        <Flame size={24} className="fill-pink-500" />
-                        <div>Vibe<span className="text-white">Match</span></div>
-                    </div>
-                    <button onClick={onClose} className="p-2 rounded-full hover:bg-[#27272a] text-gray-400 transition-colors">
-                        <X size={20} />
-                    </button>
-                </div>
+	// ── Fetch matches ──────────────────────────────────────────────────────────
 
-                {/* Card */}
-                <div className="flex-1 p-4 relative overflow-hidden flex flex-col">
-                    <div className="flex-1 bg-white rounded-2xl overflow-hidden relative shadow-md flex flex-col h-full border border-gray-200">
-                        <div className="h-64 bg-gradient-to-br from-pink-100 to-purple-200 flex items-center justify-center shrink-0">
-                            <img src={profile.picture} alt={profile.name} className="w-48 h-48 drop-shadow-xl rounded-2xl" />
-                        </div>
-                        <div className="flex-1 p-5 flex flex-col justify-start bg-white text-black">
-                            <h3 className="text-2xl font-black flex items-baseline gap-2">
-                                {profile.name} <span className="text-lg font-normal text-gray-500">{pseudoAge}</span>
-                            </h3>
-                            <div className="flex items-center gap-1 text-gray-500 mt-1 text-xs font-medium uppercase tracking-wider">
-                                <MapPin size={12} /> {profile.location}
-                            </div>
-                            <div className="flex items-center gap-1 text-pink-500 bg-pink-50 w-fit px-2 py-1 rounded-md mt-2 text-sm font-bold mb-3 border border-pink-100">
-                                <Code2 size={14} /> Writes {profile.language}
-                            </div>
-                            <p className="text-gray-700 font-medium leading-snug break-words">
-                                "{profile.bio}"
-                            </p>
-                        </div>
-                    </div>
-                </div>
+	const fetchMatches = useCallback(async () => {
+		setIsLoadingMatches(true);
+		try {
+			const token = await getAccessTokenSilently();
+			const res = await fetch(`${API_BASE}/api/match/matches`, {
+				headers: { Authorization: `Bearer ${token}` },
+			});
+			const data = await res.json();
+			if (data.success) setMatches(data.matches ?? []);
+		} catch (err) {
+			console.error("Failed to fetch matches:", err);
+		} finally {
+			setIsLoadingMatches(false);
+		}
+	}, [getAccessTokenSilently]);
 
-                {/* Actions */}
-                <div className="p-6 bg-[#18181b] flex justify-center gap-8 pb-8 border-t border-[#27272a]">
-                    <button 
-                        onClick={() => handleSwipe('left')}
-                        className="w-16 h-16 rounded-full bg-[#09090b] flex items-center justify-center border-2 border-red-500 text-red-500 hover:bg-red-500 hover:text-white transition-all shadow-[0_0_15px_rgba(239,68,68,0.2)] hover:scale-110"
-                    >
-                        <X size={28} strokeWidth={3} />
-                    </button>
-                    <button 
-                        onClick={() => handleSwipe('right')}
-                        className="w-16 h-16 rounded-full bg-[#09090b] flex items-center justify-center border-2 border-green-500 text-green-500 hover:bg-green-500 hover:text-white transition-all shadow-[0_0_15px_rgba(34,197,94,0.2)] hover:scale-110"
-                    >
-                        <Heart size={28} strokeWidth={3} className={matchMode ? "fill-white" : ""} />
-                    </button>
-                </div>
-            </div>
-        </div>
-    );
+	useEffect(() => {
+		if (screen === "matches") fetchMatches();
+	}, [screen, fetchMatches]);
+
+	// ── Swipe handler ──────────────────────────────────────────────────────────
+
+	const handleSwipe = async (direction: "left" | "right") => {
+		if (currentIndex >= users.length) return;
+		const swiped = users[currentIndex];
+		if (!swiped) return;
+
+		setLastSwipedUser(swiped);
+		setCurrentIndex((prev) => prev + 1);
+
+		try {
+			const token = await getAccessTokenSilently();
+			const res = await fetch(`${API_BASE}/api/match/swipe`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+				body: JSON.stringify({ swipedId: swiped.id, direction }),
+			});
+			const data = await res.json();
+
+			if (data.matched && data.matchId) {
+				setMatchAnimation({ user: swiped, matchId: data.matchId });
+				setTimeout(() => setMatchAnimation(null), 2500);
+			}
+		} catch (err) {
+			console.error("Swipe error:", err);
+		}
+	};
+
+	// ── Rewind handler ─────────────────────────────────────────────────────────
+
+	const handleRewind = async () => {
+		if (rewound || currentIndex === 0 || !lastSwipedUser) return;
+		setRewound(true);
+		setCurrentIndex((prev) => prev - 1);
+		try {
+			const token = await getAccessTokenSilently();
+			await fetch(`${API_BASE}/api/match/swipe/last`, {
+				method: "DELETE",
+				headers: { Authorization: `Bearer ${token}` },
+			});
+		} catch (err) {
+			console.error("Rewind error:", err);
+		}
+	};
+
+	// ── Keyboard shortcuts ─────────────────────────────────────────────────────
+
+	useEffect(() => {
+		if (screen !== "swipe") return;
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === "ArrowLeft") handleSwipe("left");
+			else if (e.key === "ArrowRight") handleSwipe("right");
+			else if (e.key === "z" || e.key === "Z") handleRewind();
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	}, [screen, currentIndex, rewound, lastSwipedUser]);
+
+	// ── Chat ───────────────────────────────────────────────────────────────────
+
+	const openChat = async (matchId: string) => {
+		setActiveMatchId(matchId);
+		setMessages([]);
+		setMessageInput(ICEBREAKERS[Math.floor(Math.random() * ICEBREAKERS.length)] ?? "");
+		setIsLoadingMessages(true);
+
+		try {
+			const token = await getAccessTokenSilently();
+			const res = await fetch(`${API_BASE}/api/match/${matchId}/messages`, {
+				headers: { Authorization: `Bearer ${token}` },
+			});
+			const data = await res.json();
+			if (data.success) {
+				setMessages(data.messages ?? []);
+				// Clear icebreaker if there are already messages
+				if ((data.messages ?? []).length > 0) setMessageInput("");
+			}
+		} catch (err) {
+			console.error("Load messages error:", err);
+		} finally {
+			setIsLoadingMessages(false);
+		}
+
+		// Open WS for real-time delivery
+		if (wsRef.current) wsRef.current.close();
+		const ws = new WebSocket(`${WS_BASE}/ws/match?matchId=${matchId}&userId=${user?._raw?.id ?? ""}`);
+		ws.onmessage = (event) => {
+			try {
+				const payload = JSON.parse(event.data);
+				if (payload.type === "new_message" && payload.message) {
+					setMessages((prev) =>
+						prev.some((m) => m.id === payload.message.id)
+							? prev
+							: [...prev, payload.message],
+					);
+				}
+			} catch (_) {}
+		};
+		wsRef.current = ws;
+	};
+
+	const closeChat = () => {
+		setActiveMatchId(null);
+		setMessages([]);
+		if (wsRef.current) {
+			wsRef.current.close();
+			wsRef.current = null;
+		}
+		fetchMatches();
+	};
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional – close WS on unmount only
+	useEffect(() => {
+		return () => {
+			wsRef.current?.close();
+		};
+	}, []);
+
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, [messages]);
+
+	const sendMessage = async () => {
+		if (!messageInput.trim() || !activeMatchId || isSending) return;
+		const body = messageInput.trim();
+		setMessageInput("");
+		setIsSending(true);
+		try {
+			const token = await getAccessTokenSilently();
+			const res = await fetch(`${API_BASE}/api/match/${activeMatchId}/messages`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+				body: JSON.stringify({ body }),
+			});
+			// Don't manually add to state — WS broadcast delivers the message to
+			// all clients in the room including the sender, avoiding duplicates.
+			if (!res.ok) throw new Error("Send failed");
+		} catch (err) {
+			console.error("Send message error:", err);
+			setMessageInput(body);
+		} finally {
+			setIsSending(false);
+		}
+	};
+
+	const handleUnmatch = async (matchId: string) => {
+		try {
+			const token = await getAccessTokenSilently();
+			await fetch(`${API_BASE}/api/match/${matchId}`, {
+				method: "DELETE",
+				headers: { Authorization: `Bearer ${token}` },
+			});
+			if (activeMatchId === matchId) closeChat();
+			setMatches((prev) => prev.filter((m) => m.id !== matchId));
+		} catch (err) {
+			console.error("Unmatch error:", err);
+		}
+	};
+
+	// ── Loading state ──────────────────────────────────────────────────────────
+
+	if (isLoadingUsers && screen === "swipe") {
+		return (
+			<div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm">
+				<div className="bg-[#18181b] border border-[#27272a] rounded-2xl p-8 flex flex-col items-center">
+					<Loader2 size={32} className="animate-spin text-pink-500 mb-4" />
+					<p className="text-white font-medium">Finding hot coders in your area...</p>
+				</div>
+			</div>
+		);
+	}
+
+	const profile = users[currentIndex];
+	const pseudoAge = profile ? 20 + (profile.id ? (profile.id.length % 15) : 4) : 0;
+	const activeMatch = matches.find((m) => m.id === activeMatchId);
+
+	return (
+		<div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+			<div className="bg-[#09090b] border border-[#27272a] rounded-3xl overflow-hidden max-w-sm w-full relative shadow-[0_0_50px_rgba(236,72,153,0.15)] flex flex-col h-[640px]">
+
+				{/* Match animation overlay */}
+				{matchAnimation && (
+					<div className="absolute inset-0 z-50 bg-black/90 flex flex-col items-center justify-center p-6 text-center">
+						<h2 className="text-4xl font-black text-transparent bg-clip-text bg-gradient-to-r from-pink-500 to-rose-500 italic mb-4 -rotate-12">
+							IT'S A MATCH!
+						</h2>
+						<p className="text-white mb-8 text-lg font-medium">
+							You and {matchAnimation.user.name} both love avoiding documentation.
+						</p>
+						<div className="flex gap-4">
+							<img
+								src={matchAnimation.user.picture}
+								alt={matchAnimation.user.name}
+								className="w-24 h-24 rounded-full border-4 border-pink-500 bg-white"
+							/>
+							<div className="w-24 h-24 rounded-full border-4 border-pink-500 flex items-center justify-center bg-gradient-to-br from-cyan-400 to-blue-600 font-bold text-2xl text-black">
+								{user?.name?.[0] ?? "V"}
+							</div>
+						</div>
+						<button
+							type="button"
+							onClick={() => {
+								setMatchAnimation(null);
+								setScreen("matches");
+								fetchMatches();
+							}}
+							className="mt-6 px-6 py-2 rounded-full bg-pink-500 text-white font-bold text-sm hover:bg-pink-600 transition-colors"
+						>
+							Send a message
+						</button>
+					</div>
+				)}
+
+				{/* Header */}
+				<div className="p-4 border-b border-[#27272a] flex justify-between items-center bg-[#18181b] shrink-0">
+					<div className="flex items-center gap-2 text-pink-500 font-bold text-xl tracking-tight">
+						<Flame size={24} className="fill-pink-500" />
+						<div>Vibe<span className="text-white">Match</span></div>
+					</div>
+					<button
+						type="button"
+						onClick={onClose}
+						className="p-2 rounded-full hover:bg-[#27272a] text-gray-400 transition-colors"
+					>
+						<X size={20} />
+					</button>
+				</div>
+
+				{/* Tab row */}
+				<div className="flex border-b border-[#27272a] bg-[#18181b] shrink-0">
+					<button
+						type="button"
+						onClick={() => setScreen("swipe")}
+						className={`flex-1 py-2.5 text-xs font-bold uppercase tracking-widest transition-colors ${
+							screen === "swipe"
+								? "text-pink-500 border-b-2 border-pink-500"
+								: "text-gray-500 hover:text-gray-300"
+						}`}
+					>
+						Swipe
+					</button>
+					<button
+						type="button"
+						onClick={() => setScreen("matches")}
+						className={`flex-1 py-2.5 text-xs font-bold uppercase tracking-widest transition-colors relative ${
+							screen === "matches"
+								? "text-pink-500 border-b-2 border-pink-500"
+								: "text-gray-500 hover:text-gray-300"
+						}`}
+					>
+						Matches
+						{matches.reduce((acc, m) => acc + m.unreadCount, 0) > 0 && (
+							<span className="absolute top-1.5 right-6 w-2 h-2 bg-pink-500 rounded-full" />
+						)}
+					</button>
+				</div>
+
+				{/* ── SWIPE SCREEN ────────────────────────────────────────────────────── */}
+				{screen === "swipe" && (
+					<>
+						{/* Order picker */}
+						<div className="px-4 pt-3 pb-1 shrink-0">
+							<select
+								value={order}
+								onChange={(e) => setOrder(e.target.value as OrderMode)}
+								className="w-full bg-[#18181b] border border-[#27272a] text-gray-300 text-xs rounded-lg px-3 py-2 focus:outline-none focus:border-pink-500 transition-colors"
+							>
+								{(Object.keys(ORDER_LABELS) as OrderMode[]).map((key) => (
+									<option key={key} value={key}>
+										{ORDER_LABELS[key]}
+									</option>
+								))}
+							</select>
+						</div>
+
+						{/* Card stack */}
+						<div className="flex-1 px-4 py-2 relative overflow-hidden flex flex-col">
+							{currentIndex >= users.length ? (
+								<div className="flex-1 flex flex-col items-center justify-center text-center">
+									<Flame className="w-12 h-12 text-pink-500 mx-auto mb-3" />
+									<h3 className="text-white font-bold text-lg mb-1">No more coders!</h3>
+									<p className="text-gray-400 text-sm mb-4">
+										You've seen everyone. Go back to coding.
+									</p>
+									<button
+										type="button"
+										onClick={() => fetchUsers(order)}
+										className="px-4 py-2 rounded-full border border-pink-500 text-pink-500 text-xs font-bold hover:bg-pink-500/10 transition-colors"
+									>
+										Refresh
+									</button>
+								</div>
+							) : profile ? (
+								<div className="flex-1 bg-white rounded-2xl overflow-hidden relative shadow-md flex flex-col border border-gray-200">
+									<div className="h-52 bg-gradient-to-br from-pink-100 to-purple-200 flex items-center justify-center shrink-0">
+										<img
+											src={profile.picture}
+											alt={profile.name}
+											className="w-40 h-40 drop-shadow-xl rounded-2xl object-cover"
+										/>
+									</div>
+									<div className="flex-1 p-4 flex flex-col bg-white text-black overflow-auto">
+										<h3 className="text-xl font-black flex items-baseline gap-2">
+											{profile.name}
+											<span className="text-base font-normal text-gray-500">{pseudoAge}</span>
+											{profile.language && (
+												<span className="ml-auto text-xs bg-pink-50 text-pink-500 border border-pink-100 px-2 py-0.5 rounded font-bold flex items-center gap-1">
+													<Code2 size={11} /> {profile.language}
+												</span>
+											)}
+										</h3>
+										{profile.location && (
+											<div className="flex items-center gap-1 text-gray-500 mt-1 text-xs font-medium">
+												<MapPin size={11} /> {profile.location}
+											</div>
+										)}
+										{profile.bio && (
+											<p className="text-gray-700 text-sm leading-snug mt-2 break-words">
+												"{profile.bio}"
+											</p>
+										)}
+									</div>
+								</div>
+							) : null}
+						</div>
+
+						{/* Action buttons */}
+						<div className="p-5 bg-[#18181b] flex justify-center gap-6 border-t border-[#27272a] shrink-0">
+							<button
+								type="button"
+								onClick={() => handleSwipe("left")}
+								className="w-14 h-14 rounded-full bg-[#09090b] flex items-center justify-center border-2 border-red-500 text-red-500 hover:bg-red-500 hover:text-white transition-all shadow-[0_0_15px_rgba(239,68,68,0.2)] hover:scale-110"
+							>
+								<X size={24} strokeWidth={3} />
+							</button>
+							<button
+								type="button"
+								onClick={handleRewind}
+								disabled={rewound || currentIndex === 0}
+								title={rewound ? "Rewind used this session" : "Undo last swipe (Z)"}
+								className="w-14 h-14 rounded-full bg-[#09090b] flex items-center justify-center border-2 border-amber-400 text-amber-400 hover:bg-amber-400 hover:text-black transition-all shadow-[0_0_15px_rgba(251,191,36,0.2)] hover:scale-110 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:hover:bg-[#09090b] disabled:hover:text-amber-400"
+							>
+								<RotateCcw size={20} strokeWidth={2.5} />
+							</button>
+							<button
+								type="button"
+								onClick={() => handleSwipe("right")}
+								className="w-14 h-14 rounded-full bg-[#09090b] flex items-center justify-center border-2 border-green-500 text-green-500 hover:bg-green-500 hover:text-white transition-all shadow-[0_0_15px_rgba(34,197,94,0.2)] hover:scale-110"
+							>
+								<Heart size={24} strokeWidth={3} />
+							</button>
+						</div>
+					</>
+				)}
+
+				{/* ── MATCHES SCREEN ───────────────────────────────────────────────────── */}
+				{screen === "matches" && !activeMatchId && (
+					<div className="flex-1 overflow-y-auto">
+						{isLoadingMatches ? (
+							<div className="flex items-center justify-center h-full">
+								<Loader2 size={24} className="animate-spin text-pink-500" />
+							</div>
+						) : matches.length === 0 ? (
+							<div className="flex flex-col items-center justify-center h-full text-center px-6">
+								<Heart size={40} className="text-gray-600 mb-3" />
+								<p className="text-gray-400 text-sm">No matches yet. Start swiping!</p>
+							</div>
+						) : (
+							<ul>
+								{matches.map((match) => (
+									<li key={match.id}>
+										<button
+											type="button"
+											onClick={() => openChat(match.id)}
+											className="w-full flex items-center gap-3 px-4 py-3 hover:bg-[#18181b] transition-colors text-left"
+										>
+											<div className="relative shrink-0">
+												{match.partner?.picture ? (
+													<img
+														src={match.partner.picture}
+														alt={match.partner.name ?? "Match"}
+														className="w-12 h-12 rounded-full object-cover border-2 border-[#27272a]"
+													/>
+												) : (
+													<div className="w-12 h-12 rounded-full bg-gradient-to-br from-pink-400 to-purple-600 border-2 border-[#27272a]" />
+												)}
+												{match.unreadCount > 0 && (
+													<span className="absolute -top-0.5 -right-0.5 w-4 h-4 bg-pink-500 rounded-full text-white text-[10px] flex items-center justify-center font-bold">
+														{match.unreadCount > 9 ? "9+" : match.unreadCount}
+													</span>
+												)}
+											</div>
+											<div className="flex-1 min-w-0">
+												<div className="flex items-center justify-between">
+													<span className="text-white font-semibold text-sm truncate">
+														{match.partner?.name ?? "Unknown"}
+													</span>
+													{match.lastMessage && (
+														<span className="text-gray-600 text-[10px] shrink-0 ml-2">
+															{new Date(match.lastMessage.created_at).toLocaleDateString()}
+														</span>
+													)}
+												</div>
+												<p className="text-gray-500 text-xs truncate mt-0.5">
+													{match.lastMessage
+														? match.lastMessage.body
+														: "Say hello!"}
+												</p>
+											</div>
+											<MessageCircle size={16} className="text-gray-600 shrink-0" />
+										</button>
+									</li>
+								))}
+							</ul>
+						)}
+					</div>
+				)}
+
+				{/* ── CHAT SCREEN ─────────────────────────────────────────────────────── */}
+				{screen === "matches" && activeMatchId && (
+					<>
+						{/* Chat header */}
+						<div className="px-4 py-3 bg-[#18181b] border-b border-[#27272a] flex items-center gap-3 shrink-0">
+							<button
+								type="button"
+								onClick={closeChat}
+								className="p-1 rounded text-gray-400 hover:text-white transition-colors"
+							>
+								<ChevronLeft size={20} />
+							</button>
+							{activeMatch?.partner?.picture && (
+								<img
+									src={activeMatch.partner.picture}
+									alt={activeMatch.partner.name ?? "Match"}
+									className="w-8 h-8 rounded-full object-cover border border-[#27272a]"
+								/>
+							)}
+							<span className="text-white font-semibold text-sm flex-1 truncate">
+								{activeMatch?.partner?.name ?? "Chat"}
+							</span>
+							<button
+								type="button"
+								onClick={() => activeMatchId && handleUnmatch(activeMatchId)}
+								title="Unmatch"
+								className="p-1.5 rounded text-gray-600 hover:text-red-500 transition-colors"
+							>
+								<UserX size={16} />
+							</button>
+						</div>
+
+						{/* Messages */}
+						<div className="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-2">
+							{isLoadingMessages ? (
+								<div className="flex items-center justify-center h-full">
+									<Loader2 size={20} className="animate-spin text-pink-500" />
+								</div>
+							) : messages.length === 0 ? (
+								<div className="flex flex-col items-center justify-center h-full text-center">
+									<p className="text-gray-500 text-xs">No messages yet. Break the ice!</p>
+								</div>
+							) : (
+								messages.map((msg) => {
+									const isMe = msg.sender_id === user?._raw?.id;
+									return (
+										<div
+											key={msg.id}
+											className={`flex items-end gap-2 ${isMe ? "justify-end" : "justify-start"}`}
+										>
+											{!isMe && activeMatch?.partner?.picture && (
+												<img
+													src={activeMatch.partner.picture}
+													alt=""
+													className="w-6 h-6 rounded-full object-cover shrink-0 mb-0.5"
+												/>
+											)}
+											<div
+												className={`max-w-[75%] px-3 py-2 text-sm leading-snug break-words ${
+													isMe
+														? "bg-pink-500 text-white rounded-2xl rounded-br-none"
+														: "bg-[#27272a] text-gray-100 rounded-2xl rounded-bl-none"
+												}`}
+											>
+												{msg.body}
+											</div>
+										</div>
+									);
+								})
+							)}
+							<div ref={messagesEndRef} />
+						</div>
+
+						{/* Message input */}
+						<div className="px-4 py-3 bg-[#18181b] border-t border-[#27272a] flex gap-2 shrink-0">
+							<input
+								type="text"
+								value={messageInput}
+								onChange={(e) => setMessageInput(e.target.value)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter" && !e.shiftKey) {
+										e.preventDefault();
+										sendMessage();
+									}
+								}}
+								placeholder="Type a message..."
+								className="flex-1 bg-[#09090b] border border-[#27272a] text-white text-sm rounded-xl px-3 py-2 focus:outline-none focus:border-pink-500 transition-colors placeholder:text-gray-600"
+							/>
+							<button
+								type="button"
+								onClick={sendMessage}
+								disabled={!messageInput.trim() || isSending}
+								className="w-9 h-9 rounded-xl bg-pink-500 flex items-center justify-center text-white hover:bg-pink-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
+							>
+								{isSending ? (
+									<Loader2 size={14} className="animate-spin" />
+								) : (
+									<Send size={14} />
+								)}
+							</button>
+						</div>
+					</>
+				)}
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/CoderMatchModal.tsx
+++ b/client/src/components/CoderMatchModal.tsx
@@ -10,6 +10,7 @@ import {
 	ChevronLeft,
 	Send,
 	UserX,
+	Github,
 } from "lucide-react";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useAuth } from "@/contexts/AuthProvider";
@@ -25,6 +26,7 @@ interface MatchUser {
 	bio: string;
 	language: string;
 	location: string;
+	github_username: string | null;
 }
 
 interface MatchEntry {
@@ -456,6 +458,18 @@ export default function CoderMatchModal({ onClose }: { onClose: () => void }) {
 											<p className="text-gray-700 text-sm leading-snug mt-2 break-words">
 												"{profile.bio}"
 											</p>
+										)}
+										{profile.github_username && (
+											<a
+												href={`https://github.com/${profile.github_username}`}
+												target="_blank"
+												rel="noopener noreferrer"
+												onClick={(e) => e.stopPropagation()}
+												className="mt-3 flex items-center gap-1.5 text-xs font-semibold text-gray-500 hover:text-gray-900 transition-colors w-fit"
+											>
+												<Github size={13} />
+												@{profile.github_username}
+											</a>
 										)}
 									</div>
 								</div>

--- a/client/src/routes/dashboard.tsx
+++ b/client/src/routes/dashboard.tsx
@@ -56,6 +56,7 @@ function DashboardPage() {
   const [deployedApps, setDeployedApps] = useState<DeployedApp[]>([]);
   const [isLoadingApps, setIsLoadingApps] = useState(false);
   const [showImportModal, setShowImportModal] = useState(false);
+  const [vibeMatchUnread, setVibeMatchUnread] = useState(0);
 
   const reposRef = useRef<HTMLDivElement>(null);
   const recentRef = useRef<HTMLDivElement>(null);
@@ -118,6 +119,30 @@ function DashboardPage() {
         .finally(() => setIsLoadingApps(false));
     }
   }, [user?.nickname, getAccessTokenSilently]);
+
+  // Poll for unread VibeMatch messages every 30s
+  useEffect(() => {
+    if (!user) return;
+    const checkUnread = async () => {
+      try {
+        const token = await getAccessTokenSilently();
+        const res = await fetch(`${API_BASE}/api/match/matches`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const data = await res.json();
+        if (data.success && Array.isArray(data.matches)) {
+          const total = (data.matches as { unreadCount: number }[]).reduce(
+            (acc, m) => acc + (m.unreadCount ?? 0),
+            0,
+          );
+          setVibeMatchUnread(total);
+        }
+      } catch (_) {}
+    };
+    checkUnread();
+    const interval = setInterval(checkUnread, 30_000);
+    return () => clearInterval(interval);
+  }, [user, getAccessTokenSilently]);
 
   const handleImport = async (repo: GithubRepo) => {
     setImportingRepoId(repo.id);
@@ -358,6 +383,9 @@ function DashboardPage() {
           >
             <span className="material-symbols-outlined text-xl">favorite</span>
             <span className="font-['Space_Grotesk'] text-[10px] uppercase tracking-[0.2em] font-bold">Vibe Match</span>
+            {vibeMatchUnread > 0 && (
+              <span className="ml-auto w-2.5 h-2.5 bg-pink-500 rounded-full animate-pulse shrink-0" />
+            )}
           </button>
         </nav>
         <div className="px-6 mt-auto">

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,7 @@ import sessionsRoutes from "./routes/sessions";
 import agentRoutes from "./routes/agent";
 import githubRoutes from "./routes/github";
 import usersRouter from "./routes/users";
+import matchRouter from "./routes/match";
 import deployRoutes from "./routes/deploy";
 import helpRoutes from "./routes/help";
 import timelineRoutes from "./routes/timeline";
@@ -18,6 +19,7 @@ import { syncProjectFilesToDisk } from "./utils/sync";
 import { supabase } from "./db/supabase";
 import * as nodePath from "node:path";
 import { scanCode, hasCriticalVulnerability, type ScanResult } from "./security/scanner";
+import { addMatchClient, removeMatchClient } from "./ws/matchMessaging";
 
 const LLM_BASE_URL = process.env.LLM_BASE_URL ?? "https://api.deepseek.com/v1";
 const LLM_KEY = process.env.LLM_KEY ?? "";
@@ -81,6 +83,7 @@ export const app = new Hono()
 	.route("/api/agent", agentRoutes)
 	.route("/api/github", githubRoutes)
 	.route("/api/users", usersRouter)
+	.route("/api/match", matchRouter)
 	.route("/api/deploy", deployRoutes)
     .route("/api/help", helpRoutes)
     .route("/api/timeline", timelineRoutes)
@@ -488,7 +491,7 @@ interface WSData {
     userName: string;
     isHost: boolean;
     color: string;
-    type: "collab" | "terminal";
+    type: "collab" | "terminal" | "match";
 }
 
 // Room tracking for host resolution
@@ -501,6 +504,17 @@ export default {
     // Manual routing wrapper around Hono to sniff WS connections instantly
 	async fetch(req: Request, server: import("bun").Server<WSData>) {
         const url = new URL(req.url);
+
+        // Match chat WebSocket — /ws/match?matchId=&userId=
+        if (url.pathname === "/ws/match") {
+            const matchId = url.searchParams.get("matchId") || "";
+            const userId = url.searchParams.get("userId") || "anon";
+            if (!matchId) return new Response("matchId required", { status: 400 });
+            if (server.upgrade(req, {
+                data: { type: "match", projectId: matchId, clientId: userId, userName: "", isHost: false, color: "" }
+            })) return;
+            return new Response("Upgrade failed", { status: 500 });
+        }
 
         // Terminals — Docker-backed collaborative sandbox
         if (url.pathname === "/ws/terminal") {
@@ -543,6 +557,13 @@ export default {
 	websocket: {
         open(ws: import("bun").ServerWebSocket<WSData>) {
             const data = ws.data;
+
+            // Match chat room
+            if (data.type === "match") {
+                addMatchClient(data.projectId, ws);
+                return;
+            }
+
             if (data.type === "terminal") {
                 ws.subscribe(`term_${data.projectId}`);
                 const roomId = data.projectId;
@@ -806,6 +827,11 @@ export default {
         },
 
         close(ws: import("bun").ServerWebSocket<WSData>) {
+            if (ws.data.type === "match") {
+                removeMatchClient(ws.data.projectId, ws);
+                return;
+            }
+
             if (ws.data.type === "terminal") {
                 ws.unsubscribe(`term_${ws.data.projectId}`);
                 const roomId = ws.data.projectId;

--- a/server/src/routes/match.ts
+++ b/server/src/routes/match.ts
@@ -1,0 +1,288 @@
+import { Hono } from "hono";
+import { supabase } from "../db/supabase";
+import { authMiddleware } from "../middleware/authMiddleware";
+import { broadcastToMatch } from "../ws/matchMessaging";
+
+type Variables = { user: { sub: string; [key: string]: any } };
+const router = new Hono<{ Variables: Variables }>();
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function matchedPair(a: string, b: string): [string, string] {
+	return a < b ? [a, b] : [b, a];
+}
+
+// ── POST /api/match/swipe ─────────────────────────────────────────────────────
+router.post("/swipe", authMiddleware, async (c) => {
+	try {
+		const currentUser = c.get("user");
+		const body = await c.req.json<{ swipedId: string; direction: "left" | "right" }>();
+
+		if (!body.swipedId || !["left", "right"].includes(body.direction)) {
+			return c.json({ success: false, error: "Invalid request" }, 400);
+		}
+
+		// Upsert swipe (handles duplicate swipe gracefully)
+		const { error: swipeError } = await supabase
+			.from("swipes")
+			.upsert(
+				{ swiper_id: currentUser.sub, swiped_id: body.swipedId, direction: body.direction },
+				{ onConflict: "swiper_id,swiped_id" },
+			);
+
+		if (swipeError) throw swipeError;
+
+		if (body.direction !== "right") {
+			return c.json({ success: true, matched: false });
+		}
+
+		// Check if the other person already swiped right on us
+		const { data: reciprocal } = await supabase
+			.from("swipes")
+			.select("id")
+			.eq("swiper_id", body.swipedId)
+			.eq("swiped_id", currentUser.sub)
+			.eq("direction", "right")
+			.maybeSingle();
+
+		if (!reciprocal) {
+			return c.json({ success: true, matched: false });
+		}
+
+		// Mutual right swipe → create match (consistent ordering: smaller UUID first)
+		const [userA, userB] = matchedPair(currentUser.sub, body.swipedId);
+		const { data: match, error: matchError } = await supabase
+			.from("matches")
+			.upsert({ user_a_id: userA, user_b_id: userB, is_active: true }, { onConflict: "user_a_id,user_b_id" })
+			.select("id")
+			.single();
+
+		if (matchError) throw matchError;
+
+		return c.json({ success: true, matched: true, matchId: match?.id });
+	} catch (error: any) {
+		console.error("[match/swipe]", error);
+		return c.json({ success: false, error: "Failed to record swipe" }, 500);
+	}
+});
+
+// ── DELETE /api/match/swipe/last ──────────────────────────────────────────────
+router.delete("/swipe/last", authMiddleware, async (c) => {
+	try {
+		const currentUser = c.get("user");
+
+		const { data: lastSwipe } = await supabase
+			.from("swipes")
+			.select("id, swiped_id, direction")
+			.eq("swiper_id", currentUser.sub)
+			.order("created_at", { ascending: false })
+			.limit(1)
+			.maybeSingle();
+
+		if (!lastSwipe) {
+			return c.json({ success: false, error: "No swipe to undo" }, 404);
+		}
+
+		await supabase.from("swipes").delete().eq("id", lastSwipe.id);
+
+		// If it was a right swipe, also remove any resulting match row
+		if (lastSwipe.direction === "right") {
+			const [userA, userB] = matchedPair(currentUser.sub, lastSwipe.swiped_id);
+			await supabase.from("matches").delete().eq("user_a_id", userA).eq("user_b_id", userB);
+		}
+
+		return c.json({ success: true });
+	} catch (error: any) {
+		console.error("[match/swipe/last DELETE]", error);
+		return c.json({ success: false, error: "Failed to undo swipe" }, 500);
+	}
+});
+
+// ── GET /api/match/matches ────────────────────────────────────────────────────
+router.get("/matches", authMiddleware, async (c) => {
+	try {
+		const currentUser = c.get("user");
+		const userId = currentUser.sub;
+
+		const { data: matches, error } = await supabase
+			.from("matches")
+			.select("id, user_a_id, user_b_id, created_at, is_active, user_a_last_read, user_b_last_read")
+			.or(`user_a_id.eq.${userId},user_b_id.eq.${userId}`)
+			.eq("is_active", true)
+			.order("created_at", { ascending: false });
+
+		if (error) throw error;
+
+		const enriched = await Promise.all(
+			(matches ?? []).map(async (match) => {
+				const partnerId = match.user_a_id === userId ? match.user_b_id : match.user_a_id;
+				const isUserA = match.user_a_id === userId;
+				const myLastRead: string | null = isUserA ? match.user_a_last_read : match.user_b_last_read;
+
+				const [partnerResult, lastMsgResult, unreadResult] = await Promise.all([
+					supabase
+						.from("users")
+						.select("id, name, picture")
+						.eq("id", partnerId)
+						.maybeSingle(),
+					supabase
+						.from("messages")
+						.select("body, sender_id, created_at")
+						.eq("match_id", match.id)
+						.order("created_at", { ascending: false })
+						.limit(1)
+						.maybeSingle(),
+					myLastRead
+						? supabase
+								.from("messages")
+								.select("id", { count: "exact", head: true })
+								.eq("match_id", match.id)
+								.neq("sender_id", userId)
+								.gt("created_at", myLastRead)
+						: supabase
+								.from("messages")
+								.select("id", { count: "exact", head: true })
+								.eq("match_id", match.id)
+								.neq("sender_id", userId),
+				]);
+
+				return {
+					id: match.id,
+					partner: partnerResult.data,
+					lastMessage: lastMsgResult.data,
+					unreadCount: unreadResult.count ?? 0,
+					createdAt: match.created_at,
+				};
+			}),
+		);
+
+		return c.json({ success: true, matches: enriched });
+	} catch (error: any) {
+		console.error("[match/matches GET]", error);
+		return c.json({ success: false, error: "Failed to fetch matches" }, 500);
+	}
+});
+
+// ── GET /api/match/:matchId/messages ─────────────────────────────────────────
+router.get("/:matchId/messages", authMiddleware, async (c) => {
+	try {
+		const currentUser = c.get("user");
+		const matchId = c.req.param("matchId");
+		const cursor = c.req.query("cursor");
+		const limit = Math.min(Number(c.req.query("limit") ?? "50"), 100);
+
+		// Verify membership
+		const { data: match } = await supabase
+			.from("matches")
+			.select("id, user_a_id, user_b_id")
+			.eq("id", matchId)
+			.or(`user_a_id.eq.${currentUser.sub},user_b_id.eq.${currentUser.sub}`)
+			.maybeSingle();
+
+		if (!match) return c.json({ success: false, error: "Match not found" }, 404);
+
+		let query = supabase
+			.from("messages")
+			.select("id, sender_id, body, created_at")
+			.eq("match_id", matchId)
+			.order("created_at", { ascending: false })
+			.limit(limit + 1);
+
+		if (cursor) {
+			query = query.lt("created_at", cursor);
+		}
+
+		const { data: messages, error } = await query;
+		if (error) throw error;
+
+		const hasMore = (messages?.length ?? 0) > limit;
+		const items = (messages ?? []).slice(0, limit).reverse();
+
+		// Mark as read
+		const isUserA = match.user_a_id === currentUser.sub;
+		const readField = isUserA ? "user_a_last_read" : "user_b_last_read";
+		await supabase.from("matches").update({ [readField]: new Date().toISOString() }).eq("id", matchId);
+
+		return c.json({
+			success: true,
+			messages: items,
+			meta: { hasMore, nextCursor: hasMore && items[0] ? items[0].created_at : null },
+		});
+	} catch (error: any) {
+		console.error("[match/:matchId/messages GET]", error);
+		return c.json({ success: false, error: "Failed to fetch messages" }, 500);
+	}
+});
+
+// ── POST /api/match/:matchId/messages ────────────────────────────────────────
+router.post("/:matchId/messages", authMiddleware, async (c) => {
+	try {
+		const currentUser = c.get("user");
+		const matchId = c.req.param("matchId");
+		const { body } = await c.req.json<{ body: string }>();
+
+		if (!body?.trim()) {
+			return c.json({ success: false, error: "Message body is required" }, 400);
+		}
+
+		// Verify membership + active
+		const { data: match } = await supabase
+			.from("matches")
+			.select("id, user_a_id, user_b_id, is_active")
+			.eq("id", matchId)
+			.or(`user_a_id.eq.${currentUser.sub},user_b_id.eq.${currentUser.sub}`)
+			.maybeSingle();
+
+		if (!match || !match.is_active) {
+			return c.json({ success: false, error: "Match not found or inactive" }, 404);
+		}
+
+		const { data: message, error } = await supabase
+			.from("messages")
+			.insert({ match_id: matchId, sender_id: currentUser.sub, body: body.trim() })
+			.select()
+			.single();
+
+		if (error) throw error;
+
+		// Update sender's last_read so they don't see their own message as unread
+		const isUserA = match.user_a_id === currentUser.sub;
+		const readField = isUserA ? "user_a_last_read" : "user_b_last_read";
+		await supabase.from("matches").update({ [readField]: new Date().toISOString() }).eq("id", matchId);
+
+		// Fan-out to WebSocket subscribers
+		broadcastToMatch(matchId, { type: "new_message", message });
+
+		return c.json({ success: true, message }, 201);
+	} catch (error: any) {
+		console.error("[match/:matchId/messages POST]", error);
+		return c.json({ success: false, error: "Failed to send message" }, 500);
+	}
+});
+
+// ── DELETE /api/match/:matchId ────────────────────────────────────────────────
+router.delete("/:matchId", authMiddleware, async (c) => {
+	try {
+		const currentUser = c.get("user");
+		const matchId = c.req.param("matchId");
+
+		const { data: match } = await supabase
+			.from("matches")
+			.select("id")
+			.eq("id", matchId)
+			.or(`user_a_id.eq.${currentUser.sub},user_b_id.eq.${currentUser.sub}`)
+			.maybeSingle();
+
+		if (!match) return c.json({ success: false, error: "Match not found" }, 404);
+
+		// Soft delete — keeps swipe record so profile won't reappear in feed
+		await supabase.from("matches").update({ is_active: false }).eq("id", matchId);
+
+		return c.json({ success: true });
+	} catch (error: any) {
+		console.error("[match/:matchId DELETE]", error);
+		return c.json({ success: false, error: "Failed to unmatch" }, 500);
+	}
+});
+
+export default router;

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -23,7 +23,7 @@ router.get("/match", authMiddleware, async (c) => {
 
         let baseQuery = supabase
             .from("users")
-            .select("id, name, email, picture, bio, language, location, created_at")
+            .select("id, name, email, picture, bio, language, location, created_at, github_username")
             .limit(20);
 
         // Exclude self + already-swiped (each neq is AND'd by PostgREST)

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -7,21 +7,83 @@ type Variables = { user: { sub: string; [key: string]: any } };
 const router = new Hono<{ Variables: Variables }>();
 
 // GET /api/users/match — return other users for coder-match feature
+// ?order=random|language|location|active|new
 router.get("/match", authMiddleware, async (c) => {
     try {
         const currentUser = c.get("user");
+        const order = c.req.query("order") ?? "random";
 
-        const { data, error } = await supabase
+        // Collect already-swiped IDs to exclude from feed
+        const { data: swiped } = await supabase
+            .from("swipes")
+            .select("swiped_id")
+            .eq("swiper_id", currentUser.sub);
+
+        const excludeIds = [(currentUser.sub as string), ...((swiped ?? []).map((s: { swiped_id: string }) => s.swiped_id))];
+
+        let baseQuery = supabase
             .from("users")
-            .select("id, name, email, picture, bio, language, location")
-            .neq("id", currentUser.sub)
+            .select("id, name, email, picture, bio, language, location, created_at")
             .limit(20);
 
+        // Exclude self + already-swiped (each neq is AND'd by PostgREST)
+        for (const id of excludeIds) {
+            baseQuery = baseQuery.neq("id", id);
+        }
+
+        switch (order) {
+            case "active":
+                // Fall back to created_at if updated_at doesn't exist
+                baseQuery = baseQuery.order("created_at", { ascending: false });
+                break;
+            case "new":
+                baseQuery = baseQuery.order("created_at", { ascending: false });
+                break;
+            case "language": {
+                // Fetch my language, then sort matches-first in JS
+                const { data: me } = await supabase
+                    .from("users")
+                    .select("language")
+                    .eq("id", currentUser.sub)
+                    .maybeSingle();
+                const { data, error } = await baseQuery;
+                if (error) throw error;
+                const myLang = me?.language ?? null;
+                const sorted = (data ?? []).sort((a, b) => {
+                    const aMatch = myLang && a.language === myLang ? 0 : 1;
+                    const bMatch = myLang && b.language === myLang ? 0 : 1;
+                    return aMatch - bMatch;
+                });
+                return c.json({ success: true, users: sorted });
+            }
+            case "location": {
+                const { data: me } = await supabase
+                    .from("users")
+                    .select("location")
+                    .eq("id", currentUser.sub)
+                    .maybeSingle();
+                const { data, error } = await baseQuery;
+                if (error) throw error;
+                const myLoc = me?.location ?? null;
+                const sorted = (data ?? []).sort((a, b) => {
+                    const aMatch = myLoc && a.location === myLoc ? 0 : 1;
+                    const bMatch = myLoc && b.location === myLoc ? 0 : 1;
+                    return aMatch - bMatch;
+                });
+                return c.json({ success: true, users: sorted });
+            }
+            default: // random — no DB ordering, shuffle in JS
+                break;
+        }
+
+        const { data, error } = await baseQuery;
         if (error) throw error;
 
-        // Shuffle for randomised matching
-        const shuffled = (data ?? []).sort(() => 0.5 - Math.random());
-        return c.json({ success: true, users: shuffled });
+        const result = order === "random"
+            ? (data ?? []).sort(() => 0.5 - Math.random())
+            : (data ?? []);
+
+        return c.json({ success: true, users: result });
     } catch (error: any) {
         console.error("Fetch match users error:", error);
         return c.json({ success: false, error: "Failed to fetch users" }, 500);

--- a/server/src/utils/tokens.ts
+++ b/server/src/utils/tokens.ts
@@ -20,6 +20,7 @@ export async function upsertUser(payload: {
         `https://ui-avatars.com/api/?name=${encodeURIComponent(
           payload.name || payload.email || "U"
         )}&background=0D8ABC&color=fff`,
+      github_username: payload.nickname || null,
       created_at: new Date().toISOString(),
     },
     { onConflict: "id", ignoreDuplicates: false }

--- a/server/src/ws/matchMessaging.ts
+++ b/server/src/ws/matchMessaging.ts
@@ -1,0 +1,28 @@
+// In-memory registry of WebSocket clients subscribed to a match chat room.
+// Used by the HTTP message POST handler to fan-out new messages in real-time.
+const matchClients = new Map<string, Set<any>>();
+
+export function addMatchClient(matchId: string, ws: any): void {
+	if (!matchClients.has(matchId)) {
+		matchClients.set(matchId, new Set());
+	}
+	matchClients.get(matchId)!.add(ws);
+}
+
+export function removeMatchClient(matchId: string, ws: any): void {
+	const clients = matchClients.get(matchId);
+	if (!clients) return;
+	clients.delete(ws);
+	if (clients.size === 0) matchClients.delete(matchId);
+}
+
+export function broadcastToMatch(matchId: string, message: object): void {
+	const clients = matchClients.get(matchId);
+	if (!clients) return;
+	const json = JSON.stringify(message);
+	for (const client of clients) {
+		try {
+			client.send(json);
+		} catch (_) {}
+	}
+}

--- a/supabase-vibematch-migration.sql
+++ b/supabase-vibematch-migration.sql
@@ -1,0 +1,44 @@
+-- VibeMatch persistent matching tables
+-- Run this in your Supabase SQL editor (project dashboard → SQL Editor)
+
+-- Swipes: one row per swiper/swiped pair, direction is 'left' or 'right'
+create table if not exists swipes (
+  id        uuid primary key default gen_random_uuid(),
+  swiper_id text not null,
+  swiped_id text not null,
+  direction text not null check (direction in ('left', 'right')),
+  created_at timestamptz default now(),
+  unique (swiper_id, swiped_id)
+);
+
+create index if not exists swipes_swiper_idx on swipes(swiper_id);
+create index if not exists swipes_swiped_idx on swipes(swiped_id);
+
+-- Matches: created when both users swiped right on each other.
+-- user_a_id < user_b_id always (lexicographic) for stable uniqueness.
+-- is_active=false means soft-deleted (unmatched) — swipe record kept so
+-- the profile never reappears in the feed.
+create table if not exists matches (
+  id              uuid primary key default gen_random_uuid(),
+  user_a_id       text not null,
+  user_b_id       text not null,
+  is_active       boolean not null default true,
+  user_a_last_read timestamptz,
+  user_b_last_read timestamptz,
+  created_at      timestamptz default now(),
+  unique (user_a_id, user_b_id)
+);
+
+create index if not exists matches_user_a_idx on matches(user_a_id);
+create index if not exists matches_user_b_idx on matches(user_b_id);
+
+-- Messages: stored permanently, cascade-deleted when a match row is deleted.
+create table if not exists messages (
+  id         uuid primary key default gen_random_uuid(),
+  match_id   uuid not null references matches(id) on delete cascade,
+  sender_id  text not null,
+  body       text not null,
+  created_at timestamptz default now()
+);
+
+create index if not exists messages_match_idx on messages(match_id, created_at desc);


### PR DESCRIPTION
  Summary

  - Transforms VibeMatch from a cosmetic feature (coin-flip matches, no persistence) into a fully functional developer discovery system
  - Every swipe is recorded server-side; swiped profiles never reappear in any feed ordering
  - Mutual right-swipes create a persistent match with a dedicated messaging thread
  - Real-time message delivery via WebSocket; full history survives page reloads
  - Modal gains a two-screen structure (Swipe / Matches) with inline chat

  What changed

  Backend — 3 new/modified files

  - server/src/routes/match.ts (new) — 6 endpoints: POST /swipe, DELETE /swipe/last (rewind), GET /matches (with unread counts), GET /:matchId/messages
  (cursor-paginated), POST /:matchId/messages, DELETE /:matchId (soft unmatch)
  - server/src/ws/matchMessaging.ts (new) — in-memory registry of WebSocket clients per match room; broadcastToMatch() called by the HTTP message handler for real-time
  fan-out
  - server/src/routes/users.ts — GET /api/users/match now excludes already-swiped profiles and accepts ?order=random|language|location|active|new
  - server/src/utils/tokens.ts — upsertUser now persists github_username (GitHub handle from OAuth metadata)
  - server/src/index.ts — mounts /api/match router; adds /ws/match?matchId=&userId= WebSocket upgrade path

  Frontend — 2 modified files

  - client/src/components/CoderMatchModal.tsx — full rewrite; two-screen modal (Swipe tab + Matches tab); order picker; ✗ / ↩ / ♥ buttons with rewind (disabled after
  one use per session); match animation only on server-confirmed mutual match; inline chat with real-time WS delivery; icebreaker pre-fill; unmatch; GitHub profile
  link on card; keyboard shortcuts (← → Z)
  - client/src/routes/dashboard.tsx — polls GET /api/match/matches every 30s; shows pulsing pink dot on Vibe Match sidebar button when unread messages exist

  Database

  - supabase-vibematch-migration.sql — creates swipes, matches, messages tables with indexes and constraints (run in Supabase SQL Editor)
  - ALTER TABLE users ADD COLUMN IF NOT EXISTS github_username text — one additional column needed

  Test plan

  - [ ] Swipe right on a user → row appears in swipes table; profile doesn't reappear after modal reopen
  - [ ] Two users swipe right on each other → match animation fires; row appears in matches; both see each other in Matches tab
  - [ ] Send a message → recipient sees it in real-time without refresh; history persists after reopen
  - [ ] Rewind button (↩) undoes last swipe server-side; disables after one use
  - [ ] Unmatch → thread hidden for both; profile stays excluded from feed
  - [ ] All five ordering modes (random / language / location / active / new) return results excluding swiped profiles
  - [ ] Unread badge appears on sidebar Vibe Match button when there are unread messages
  - [ ] GitHub profile link appears on card and opens correct GitHub profile in new tab